### PR TITLE
Fix podAntiAffinity to work on cluster with less nodes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -12,6 +12,19 @@ metadata:
     {%- endfor %}
 spec:
   replicas: {{ data.replicas }}
+
+  {% if data.replicas > 1 %}
+  {# This is to avoid issues with the podAntiAffinity rule in clusters with the
+  same amount of nodes as the replicas requested. This strategy will remove a
+  pod before creating the new one. However, we shouldn't use it when the number
+  of replicas is just one because it will cause downtime #}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  {% endif %}
+
   selector:
     matchLabels:
       app: {{ data.get('app_name') or domain }}
@@ -21,6 +34,7 @@ spec:
         app: {{ data.get('app_name') or domain }}
     spec:
       affinity:
+        {# This rule is to avoid having pods in the same node #}
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:


### PR DESCRIPTION
Our current podAntiAffinity rule was a request of IS to make our cluster more reliable by not having multiple pods running on the same node.

At the moment, podAntiAffinity can cause issues when the number of replicas = the number of nodes in the cluster. This is because K8s do a rolling update by adding new pods before removing the old ones, this change will change the k8s strategy order so it will remove first and then add.

Some conversations about this issue can be found here: https://github.com/kubernetes/kubernetes/issues/56539 The solution chosen: https://stackoverflow.com/questions/47332137/ignore-pod-anti-affinity-during-deployment-update

## QA
Use a configuration file with replicas > 1 and run:
```
./konf.py production --type Site ./konf.yaml | grep rollingUpdate
```
It should output that rollingUpdate is present


Use a configuration file with replicas = 1 and run:
```
./konf.py production --type Site ./konf.yaml | grep rollingUpdate
```
We shouldn't have any output