### PR TITLE
Remove podAntiAffinity to work on cluster with less nodes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -20,16 +20,6 @@ spec:
       labels:
         app: {{ data.get('app_name') or domain }}
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - {{ data.get('app_name') or domain }}
-            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: {{ data.get('name') or get_site_name() }}
           image: {{ data.image }}:{{ tag | default("latest", true) }}


### PR DESCRIPTION
Our current podAntiAffinity rule was established to ensure our cluster is reliable by not having multiple pods running on the same node.

At the moment, podAntiAffinity is causing issues when the number of replicas = the number of nodes in the cluster. This is because K8s do a rolling update by adding new pods before removing the old ones. Because of this and after discussing it on https://github.com/canonical/konf/pull/35, we decided to remove this rule.