### PR TITLE
Add nginx proxy body size option 

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -6,7 +6,6 @@ import os
 import jinja2
 import yaml
 
-
 BASE_DIR = os.getenv("SNAP", ".")
 TEMPLATES_DIR = BASE_DIR + "/templates"
 
@@ -73,6 +72,7 @@ class Konf:
         labels,
         overrides,
         new_k8s_version,
+        nginx_proxy_body_size,
     ):
         self.deployment_env = env
         self.values_file = values_file
@@ -83,6 +83,7 @@ class Konf:
         self.labels = {
             key: value for key, value in (label.split("=") for label in labels)
         }
+        self.nginx_proxy_body_size = nginx_proxy_body_size
         self.new_k8s_version = new_k8s_version
         # Load project data
         self.load_values()
@@ -135,6 +136,7 @@ class Konf:
             labels=self.labels,
             namespace=self.namespace,
             deployment_env=self.deployment_env,
+            nginx_proxy_body_size=self.nginx_proxy_body_size,
             new_k8s_version=self.new_k8s_version,
         )
 
@@ -293,6 +295,13 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         dest="labels",
+    )
+
+    parser.add_argument(
+        "--nginx-proxy-body-size",
+        type=str,
+        nargs="?",
+        dest="nginx_proxy_body_size",
     )
 
     # TODO: make this the default behavior once we move away from k8s < v1.21

--- a/templates/ingress-new.yaml
+++ b/templates/ingress-new.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    {%- if nginx_proxy_body_size %}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ nginx_proxy_body_size }}
+    {%- endif %}
     {%- if "nginxConfigurationSnippet" in data %}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ data.nginxConfigurationSnippet | indent(6) }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,8 +8,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/use-regex: "true"
-    {%- if "nginxProxyBodySize" in data %}
-    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    {%- if nginx_proxy_body_size %}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ nginx_proxy_body_size }}
     {%- endif %}
     {%- if "nginxConfigurationSnippet" in data %}
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    {%- if "nginxProxyBodySize" in data %}
+    nginx.ingress.kubernetes.io/proxy-body-size: 8m
+    {%- endif %}
     {%- if "nginxConfigurationSnippet" in data %}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ data.nginxConfigurationSnippet | indent(6) }}


### PR DESCRIPTION
## Done

Add a new argument to konf CLI e.g. `--nginx-proxy-body-size=9m` that returns an NGINX option to increase the request body size limit from the default 1Mb

## QA

Get this konf file: https://pastebin.canonical.com/p/4ZSKx9tVzt/
Run:
```bash
# Shouldn't see a match
./konf.py production konf.yaml | grep proxy-body-size

# Should find a match
./konf.py production --nginx-proxy-body-size=9m konf.yaml | grep proxy-body-size
```

