### PR TITLE
Allow nginx proxy body size setting in konf/site.yaml

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,6 +10,8 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     {%- if nginx_proxy_body_size %}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ nginx_proxy_body_size }}
+    {%- elif "nginx_proxy_body_size" in data %}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ data.nginx_proxy_body_size }}
     {%- endif %}
     {%- if "nginxConfigurationSnippet" in data %}
     nginx.ingress.kubernetes.io/configuration-snippet: |


### PR DESCRIPTION
## QA

Clone this branch, and clone [this branch of assets.ubuntu.com](https://github.com/canonical/konf/pull/40) side by side.

Inside this repo run:

``` bash
python3 -m venv .venv
source .venv/bin/activate
pip3 install -r requirements.txt
./konf.py production ../assets.ubuntu.com/konf/site.yaml  # Assuming this is the right place
```

You should see this in the output:

``` yaml
  annotations:                                                                                                                                                                             kubernetes.io/ingress.class: "nginx"                                                   
    nginx.ingress.kubernetes.io/use-regex: "true"
    nginx.ingress.kubernetes.io/proxy-body-size: 50m   # This is the important line
```
