### PR TITLE
Update ingress.yaml

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,7 @@
 ---
 
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ get_site_name(True) }}
   namespace: {{ namespace }}


### PR DESCRIPTION
# Done

- Updated ingress apiVersion to meet server version v1.21.14, following deprecation of `networking.k8s.io/v1beta1`

> Warning: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress