### PR TITLE
Gracefully handle secret env variables for demos

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,12 +49,13 @@ spec:
               {%- if "value" in env %}
               value: "{{ env.value }}"
               {%- endif %}
-
-              {%- if "secretKeyRef" in env %}
+              {%- if "valueFrom" in env %}
               valueFrom:
+                {%- if "secretKeyRef" in env.valueFrom %}
                 secretKeyRef:
-                  key: {{ env.secretKeyRef.key }}
-                  name: {{ env.secretKeyRef.name }}
+                  key: {{ env.valueFrom.secretKeyRef.key }}
+                  name: {{ env.valueFrom.secretKeyRef.name }}
+                {%- endif %}
               {%- endif %}
 
               {%- if "configMapKeyRef" in env %}


### PR DESCRIPTION
## Done
- Fixed an issue with formatting secret env variables. 

## QA
Clone the repo, and install the dependencies
```bash
$ python -m pip install -r requirements.txt
```
Create a simple yaml file, with k8s secrets format
```yaml
image: registry.canonical.com/sites-image
env:
  - name: BUILD_URL
    value: someBuildUrl
  - name: A_SECRET
    valueFrom:
      secretKeyRef:
        key: key_of_a
        name: webteam
  - name: B_SECRET
    valueFrom:
      secretKeyRef:
        key: key-of-b
        name: webteam
```
Then run konf
```bash
python konf.py demo placeholder.yaml -o domain="" tlsName=demos-haus secretKey=demos-haus --tag demo-building-url
```
In the output, check the `kind: Deployment` section and confirm that the secrets were correctly copied  