### PR TITLE
Added canonical.design to proxy settings

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install konf snap
         run: sudo snap install --dangerous konf_*.snap
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: konf-snap
           path: konf_*.snap

--- a/templates/proxy-settings.yaml
+++ b/templates/proxy-settings.yaml
@@ -5,4 +5,4 @@
   value: "http://squid.internal:3128/"
 
 - name: NO_PROXY
-  value: "10.24.0.132,10.24.0.23,.internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io"
+  value: "10.24.0.132,10.24.0.23,.internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"


### PR DESCRIPTION
## Done
- Added proxy config for `canonical.design` and `.canonical.design`

## QA
- Clone this repo and generate kubernetes yamls for a site using
```bash
# E.g. To deploy the snapcraft.io services to staging
./konf.py staging snapcraft.io/konf/site.yaml --tag tests
```
- Check that the env variable `NO_PROXY` is updated with `.canonical.design`