### PR TITLE
feat: added ephemeral storage options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML==6.0
+PyYAML==6.0.2
 Jinja2==3.1.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -78,5 +78,7 @@ spec:
           resources:
             limits:
               memory: {{ data.memoryLimit | default("256Mi") }}
+              ephemeral-storage: {{ data.ephemeralStorageLimit | default("256Mi") }}
             requests:
               memory: {{ data.memoryRequest | default("128Mi") }}
+              ephemeral-storage: {{ data.ephemeralStorageLimit | default("128Mi") }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,4 +81,4 @@ spec:
               ephemeral-storage: {{ data.ephemeralStorageLimit | default("256Mi") }}
             requests:
               memory: {{ data.memoryRequest | default("128Mi") }}
-              ephemeral-storage: {{ data.ephemeralStorageLimit | default("128Mi") }}
+              ephemeral-storage: {{ data.ephemeralStorageRequest | default("128Mi") }}


### PR DESCRIPTION
## Done
- Added ephemeral storage flags to allow pods to set these in k8s

## QA
- Clone this branch locally, copy a sites konf/site.yaml file to this directory, and run konf
```bash
cp ubuntu.com/konf/site.yaml konf/
cd konf
./konf.py staging site.yaml | grep -B 2 eph
````
- Confirm that there are no errors and that the default values for requests (128mb) and limits (512mb) are set.
- Edit the site.yaml and add this section to staging.routes
```yaml
    - paths: [/tests]
      name: ubuntu-com-tests
      app_name: ubuntu.com-test
      image: prod-comms.ps5.docker-registry.canonical.com/ubuntu.com
      replicas: 3
      memoryLimit: 512Mi
      ephemeralStorageLimit: 368Mi
      ephemeralStorageRequest: 998Mi
```
- Run konf again and check that these values were updated 
```bash
./konf.py staging site.yaml |  grep -A 4 368
```