### PR TITLE
feat: added replica and mem limits to staging and demos

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import contextlib
 import os
 
 import jinja2
@@ -98,9 +99,7 @@ class Konf:
                 envs.append({"name": "DATABASE_URL", "value": database_url})
 
             # Replace in top level "env" definition
-            _replace_database_url(
-                self.values.get("env", []), self.database_url
-            )
+            _replace_database_url(self.values.get("env", []), self.database_url)
 
             # Replace in routes "env" definitions
             if self.deployment_env in self.values:
@@ -226,18 +225,43 @@ class KonfSite(Konf):
         self.namespace = self.deployment_env
 
         # QA overrides
-        if self.local_qa or self.deployment_env == "demo":
+        if (
+            self.local_qa
+            or self.deployment_env == "demo"
+            or self.deployment_env == "staging"
+        ):
             self.namespace = "default"
             self.values["replicas"] = 1
 
             for route in self.values.get("routes", []):
                 route.update({"replicas": 1})
+                # hard upper memory limit for staging
+                limit = self.get_memory_value(route.get("memoryLimit"))
+                route.update({"memoryLimit": limit})
 
         if self.docker_tag:
             self.tag = self.docker_tag
 
     def render(self, template_file="site.yaml"):
         return super(KonfSite, self).render(template_file)
+
+    def get_memory_value(self, value):
+        """
+        Get the numeric value of a kubernetes formatted memory string, e.g
+        512Mi, 1Gi, and limit to 1Gi on staging.
+        """
+        limit = ""
+        with contextlib.suppress(ValueError):
+            limit, _ = value.get("memoryLimit").split("M")[0]
+            if int(limit) > 1000:
+                return "1000Mi"
+
+        with contextlib.suppress(ValueError):
+            limit, _ = value.get("memoryLimit").split("G")[0]
+            if int(limit) > 1:
+                return "1Gi"
+
+        return value
 
 
 if __name__ == "__main__":

--- a/konf.py
+++ b/konf.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import contextlib
 import os
 
 import jinja2
@@ -235,9 +234,13 @@ class KonfSite(Konf):
 
             for route in self.values.get("routes", []):
                 route.update({"replicas": 1})
-                # hard upper memory limit for staging
-                limit = self.get_memory_value(route.get("memoryLimit"))
-                route.update({"memoryLimit": limit})
+                # hard upper memory limit for staging/demo
+                # memoryLimit is always defined in Mi or Gi
+                memory_limit = self.get_memory_value(route.get("memoryLimit"))
+                request_limit = self.get_memory_value(route.get("memoryRequest"))
+                route.update(
+                    {"memoryLimit": memory_limit, "memoryRequest": request_limit}
+                )
 
         if self.docker_tag:
             self.tag = self.docker_tag
@@ -249,15 +252,19 @@ class KonfSite(Konf):
         """
         Get the numeric value of a kubernetes formatted memory string, e.g
         512Mi, 1Gi, and limit to 1Gi on staging.
-        """
-        limit = ""
-        with contextlib.suppress(ValueError):
-            limit, _ = value.get("memoryLimit").split("M")[0]
-            if int(limit) > 1000:
-                return "1000Mi"
 
-        with contextlib.suppress(ValueError):
-            limit, _ = value.get("memoryLimit").split("G")[0]
+        Default is 128Mi if no value is provided.
+        """
+        if not value:
+            return "128Mi"
+
+        if value.find("Mi") > 0:
+            limit = value.split("Mi")[0]
+            if int(limit) > 1000:
+                return "1Gi"
+
+        if value.find("Gi") > 0:
+            limit = value.split("Gi")[0]
             if int(limit) > 1:
                 return "1Gi"
 

--- a/konf.py
+++ b/konf.py
@@ -98,7 +98,9 @@ class Konf:
                 envs.append({"name": "DATABASE_URL", "value": database_url})
 
             # Replace in top level "env" definition
-            _replace_database_url(self.values.get("env", []), self.database_url)
+            _replace_database_url(
+                self.values.get("env", []), self.database_url
+            )
 
             # Replace in routes "env" definitions
             if self.deployment_env in self.values:
@@ -237,9 +239,14 @@ class KonfSite(Konf):
                 # hard upper memory limit for staging/demo
                 # memoryLimit is always defined in Mi or Gi
                 memory_limit = self.get_memory_value(route.get("memoryLimit"))
-                request_limit = self.get_memory_value(route.get("memoryRequest"))
+                request_limit = self.get_memory_value(
+                    route.get("memoryRequest")
+                )
                 route.update(
-                    {"memoryLimit": memory_limit, "memoryRequest": request_limit}
+                    {
+                        "memoryLimit": memory_limit,
+                        "memoryRequest": request_limit,
+                    }
                 )
 
         if self.docker_tag:


### PR DESCRIPTION
## Done
- Added memory and replica limits to staging and demo instances to prevent overutilization of scarce PS5 resources which are shared between staging and production.

## QA
- Clone this branch and install konf with 
```bash
pip install .
```
- Run konf against one of our updated sites
```bash
./konf.py staging ubuntu.com/konf/site.yaml
./konf.py demo ubuntu.com/konf/site.yaml
./konf.py production ubuntu.com/konf/site.yaml
```

## Fixes
[WD-31862](https://warthogs.atlassian.net/browse/WD-31862)

[WD-31862]: https://warthogs.atlassian.net/browse/WD-31862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ