### PR TITLE
FEAT: Add FLASK_DEBUG environment variable to staging values

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -234,6 +234,8 @@ class KonfSite(Konf):
             self.values["replicas"] = 1
 
             # FLASK_DEBUG is set to 1 for staging and demo environments
+            # to expose a human friendly stack trace in case of errors. 
+            # It is not set for production to avoid exposing sensitive information.
             envs = self.values.get("env", [])
             envs = [x for x in envs if x["name"] != "FLASK_DEBUG"]
             envs.append({"name": "FLASK_DEBUG", "value": "1"})

--- a/konf.py
+++ b/konf.py
@@ -196,10 +196,6 @@ class KonfSite(Konf):
             staging_values.pop("routes", None)
             staging_values.pop("nginxConfigurationSnippet", None)
             staging_values.pop("nginxServerSnippet", None)
-            env = self.values.get("env")
-            env.append({"name": "FLASK_DEBUG", "value": 1})
-
-
             self.values.update(staging_values)
 
         for override in self.overrides:
@@ -236,6 +232,13 @@ class KonfSite(Konf):
         ):
             self.namespace = "default"
             self.values["replicas"] = 1
+
+            # FLASK_DEBUG is set to 1 for staging and demo environments
+            envs = self.values.get("env", [])
+            envs = [x for x in envs if x["name"] != "FLASK_DEBUG"]
+            envs.append({"name": "FLASK_DEBUG", "value": "1"})
+            self.values["env"] = envs
+
 
             for route in self.values.get("routes", []):
                 route.update({"replicas": 1})

--- a/konf.py
+++ b/konf.py
@@ -234,8 +234,8 @@ class KonfSite(Konf):
             self.values["replicas"] = 1
 
             # FLASK_DEBUG is set to 1 for staging and demo environments
-            # to expose a human friendly stack trace in case of errors. 
-            # It is not set for production to avoid exposing sensitive information.
+            # to expose a human friendly stack trace in case of errors.
+            # It is not set for production to avoid exposing sensitive info.
             envs = self.values.get("env", [])
             envs = [x for x in envs if x["name"] != "FLASK_DEBUG"]
             envs.append({"name": "FLASK_DEBUG", "value": "1"})

--- a/konf.py
+++ b/konf.py
@@ -196,6 +196,9 @@ class KonfSite(Konf):
             staging_values.pop("routes", None)
             staging_values.pop("nginxConfigurationSnippet", None)
             staging_values.pop("nginxServerSnippet", None)
+            env = self.values.get("env")
+            env.append({"name": "FLASK_DEBUG", "value": 1})
+
 
             self.values.update(staging_values)
 

--- a/konf.py
+++ b/konf.py
@@ -239,7 +239,6 @@ class KonfSite(Konf):
             envs.append({"name": "FLASK_DEBUG", "value": "1"})
             self.values["env"] = envs
 
-
             for route in self.values.get("routes", []):
                 route.update({"replicas": 1})
                 # hard upper memory limit for staging/demo


### PR DESCRIPTION
## Done
Added `FLASK_DEBUG` environment variable to staging values

## QA
- Clone this branch
- Install a virtual env and the python dependencies
```bash
venv .venv
source .venv/bin/activate
pip install .
```
- Clone one of the sites repos, e.g [canonical.com](https://github.com/canonical/canonical.com/)
- Run the `konf.py` module using the `demo` argument, check the generated file for the `FLASK_DEBUG` variables, and confirm that the value is `1`
```bash
python3 konf.py demo ../canonical.com/konf/site.yaml | grep -A 3 FLASK
. . .
            - name: FLASK_DEBUG
              value: "1"
```
