### PR TITLE
templates: support nginxProxyBufferSize for proxy-buffer-size annotation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,14 +9,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install Snapcraft
-        run: sudo snap install snapcraft --classic
-
       - name: Build Konf snap
-        run: snapcraft pack --destructive-mode
+        uses: snapcore/action-build@v1
+        id: build
 
       - name: Install konf snap
-        run: sudo snap install --dangerous konf_*.snap
+        run: sudo snap install --dangerous ${{ steps.build.outputs.snap }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
         run: sudo snap install snapcraft --classic
 
       - name: Build Konf snap
-        run: /snap/bin/snapcraft --destructive-mode
+        run: snapcraft pack --destructive-mode
 
       - name: Install konf snap
         run: sudo snap install --dangerous konf_*.snap

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
     name="konf",
     version="1.0.0",
     install_requires=requirements,
+    py_modules=["konf"],
     scripts=["konf.py"],
 )

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: konf
-base: core20
+base: core22
 
 version: git
 
@@ -13,7 +13,6 @@ confinement: strict
 
 architectures:
   - build-on: amd64
-    run-on: amd64
 
 parts:
   konf-templates:

--- a/templates/ingress-new.yaml
+++ b/templates/ingress-new.yaml
@@ -11,6 +11,9 @@ metadata:
     {%- if nginx_proxy_body_size %}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ nginx_proxy_body_size }}
     {%- endif %}
+    {%- if "nginxProxyBufferSize" in data %}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "{{ data.nginxProxyBufferSize }}"
+    {%- endif %}
     {%- if "nginxConfigurationSnippet" in data %}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ data.nginxConfigurationSnippet | indent(6) }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     {%- elif "nginx_proxy_body_size" in data %}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ data.nginx_proxy_body_size }}
     {%- endif %}
+    {%- if "nginxProxyBufferSize" in data %}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "{{ data.nginxProxyBufferSize }}"
+    {%- endif %}
     {%- if "nginxConfigurationSnippet" in data %}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ data.nginxConfigurationSnippet | indent(6) }}


### PR DESCRIPTION
## Done

- Added an optional `nginxProxyBufferSize` site.yaml key, rendered as the `nginx.ingress.kubernetes.io/proxy-buffer-size` annotation on the Ingress (both `ingress.yaml` and `ingress-new.yaml` templates).

## Why

ubuntu.com's Content-Security-Policy response header exceeds ingress-nginx's default 4k `proxy_buffer_size`, 502-ing `/login` in production and on demos ("upstream sent too big header"). Production is currently held together by a manual `kubectl annotate`.

The annotation is the only per-ingress way to raise the buffer:
- konf has no passthrough for arbitrary annotations.
- Putting `proxy_buffer_size` in `nginxConfigurationSnippet` fails: ingress-nginx already renders that directive in every location ([nginx.tmpl](https://github.com/kubernetes/ingress-nginx/blob/main/rootfs/etc/nginx/template/nginx.tmpl#L1338-L1339)), so the snippet duplicates it and nginx rejects the whole config (`[emerg] "proxy_buffer_size" directive is duplicate`) — this briefly blocked config reloads on the demos cluster.
- The annotation instead sets the value ingress-nginx itself renders, and `proxy_buffers` scales with it automatically.

Follows the existing pattern of the other `nginx*` keys. Behaviour is unchanged when the key is absent.

## QA

Rendered the template with `data={'nginxProxyBufferSize': '16k'}`: the annotation appears as `nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"`; without the key the output is byte-identical to before.

Once released to the snap, ubuntu.com will set `nginxProxyBufferSize: 16k` in its site.yaml (canonical/ubuntu.com#16603).

Fixes [WD-37807](https://warthogs.atlassian.net/browse/WD-37807)

[WD-37807]: https://warthogs.atlassian.net/browse/WD-37807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ