### PR TITLE
konf.py: stop forcing staging into the default namespace

### DIFF
--- a/konf.py
+++ b/konf.py
@@ -224,21 +224,22 @@ class KonfSite(Konf):
         # Set deployment environment namespace
         self.namespace = self.deployment_env
 
-        # QA overrides: single replica in the default namespace.
-        # Applies to demos and local QA only — staging keeps its own
-        # namespace and site.yaml replica counts.
+        # Demos and local QA deploy into the shared default namespace.
+        # Staging keeps its own namespace — it must NOT be added here
+        # (doing so relocates every site's staging stack; see #54).
         if self.local_qa or self.deployment_env == "demo":
             self.namespace = "default"
-            self.values["replicas"] = 1
 
-            for route in self.values.get("routes", []):
-                route.update({"replicas": 1})
-
+        # Resource limits for non-production environments (WD-31862):
+        # single replica and memory caps to avoid over-utilising PS5
+        # resources shared with production.
         if (
             self.local_qa
             or self.deployment_env == "demo"
             or self.deployment_env == "staging"
         ):
+            self.values["replicas"] = 1
+
             # FLASK_DEBUG is set to 1 for staging and demo environments
             # to expose a human friendly stack trace in case of errors.
             # It is not set for production to avoid exposing sensitive info.
@@ -248,6 +249,7 @@ class KonfSite(Konf):
             self.values["env"] = envs
 
             for route in self.values.get("routes", []):
+                route.update({"replicas": 1})
                 # hard upper memory limit for staging/demo
                 # memoryLimit is always defined in Mi or Gi
                 memory_limit = self.get_memory_value(route.get("memoryLimit"))

--- a/konf.py
+++ b/konf.py
@@ -224,15 +224,21 @@ class KonfSite(Konf):
         # Set deployment environment namespace
         self.namespace = self.deployment_env
 
-        # QA overrides
+        # QA overrides: single replica in the default namespace.
+        # Applies to demos and local QA only — staging keeps its own
+        # namespace and site.yaml replica counts.
+        if self.local_qa or self.deployment_env == "demo":
+            self.namespace = "default"
+            self.values["replicas"] = 1
+
+            for route in self.values.get("routes", []):
+                route.update({"replicas": 1})
+
         if (
             self.local_qa
             or self.deployment_env == "demo"
             or self.deployment_env == "staging"
         ):
-            self.namespace = "default"
-            self.values["replicas"] = 1
-
             # FLASK_DEBUG is set to 1 for staging and demo environments
             # to expose a human friendly stack trace in case of errors.
             # It is not set for production to avoid exposing sensitive info.
@@ -242,7 +248,6 @@ class KonfSite(Konf):
             self.values["env"] = envs
 
             for route in self.values.get("routes", []):
-                route.update({"replicas": 1})
                 # hard upper memory limit for staging/demo
                 # memoryLimit is always defined in Mi or Gi
                 memory_limit = self.get_memory_value(route.get("memoryLimit"))


### PR DESCRIPTION
#51 added staging to the block that also sets `namespace = "default"`, so hosts on the edge snap now deploy staging stacks into the default namespace. This started happening on shared Jenkins agents this week and several sites' staging ended up in the wrong namespace.

The namespace change isn't mentioned in #51 or WD-31862, so I'm treating it as accidental. This PR fixes only that: staging goes back to its own namespace, while demos and local QA keep deploying to default. Everything #51 was actually for is kept — single replica, memory caps and FLASK_DEBUG still apply to staging.

Checked by rendering ubuntu.com's site.yaml:

- `konf staging`: all resources back in the staging namespace, limits still applied
- `konf demo`: output identical to main
- `konf production`: untouched

https://warthogs.atlassian.net/browse/WD-37895

Note: staging drops to 1 replica on its first deploy after release. That's #51 doing what it said it would, but it will be visible.
